### PR TITLE
fix: make header and footer full width

### DIFF
--- a/public/css/portfolio.css
+++ b/public/css/portfolio.css
@@ -8,9 +8,12 @@ body {
   font-family: 'Outfit', sans-serif;
   background: #F5F4F1;
   color: #1A1918;
+  overflow-x: hidden;
+}
+
+.container {
   max-width: 1200px;
   margin: 0 auto;
-  overflow-x: hidden;
 }
 
 a {

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     </nav>
   </header>
 
+  <main class="container">
   <!-- Hero -->
   <section class="hero" id="about">
     <img src="/img/avatar.jpg" alt="avatar" class="avatar">
@@ -228,6 +229,7 @@
       </div>
     </div>
   </section>
+  </main>
 
   <!-- Footer -->
   <footer class="footer">


### PR DESCRIPTION
Move max-width constraint from body to a .container wrapper. Header and footer now span full viewport width while main content stays centered within 1200px max width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted horizontal overflow handling by moving overflow suppression from the container to the body element.
  * Reorganized main content structure with an added semantic wrapper for improved layout organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->